### PR TITLE
Improve recurring contribution form

### DIFF
--- a/CRM/Rcont/Form/RecurEdit.php
+++ b/CRM/Rcont/Form/RecurEdit.php
@@ -251,14 +251,16 @@ class CRM_Rcont_Form_RecurEdit extends CRM_Core_Form {
   public function postProcess() {
     $values = $this->exportValues();
 
-    // store last selection (per user)
-    $session = CRM_Core_Session::singleton();
-    $user_contact = (int) $session->get('userID');
-    CRM_Core_BAO_Setting::setItem($values['campaign_id'],            'de.systopia.rcont', 'last_campaign_id', NULL, $user_contact);
-    CRM_Core_BAO_Setting::setItem($values['cycle_day'],              'de.systopia.rcont', 'last_cycle_day', NULL, $user_contact);
-    CRM_Core_BAO_Setting::setItem($values['financial_type_id'],      'de.systopia.rcont', 'last_financial_type_id', NULL, $user_contact);
-    CRM_Core_BAO_Setting::setItem($values['frequency'],              'de.systopia.rcont', 'last_frequency', NULL, $user_contact);
-    CRM_Core_BAO_Setting::setItem($values['contribution_status_id'], 'de.systopia.rcont', 'last_contribution_status_id', NULL, $user_contact);
+    if (Civi::settings()->get('rcont_remember_values')) {
+      // store last selection (per user)
+      $session = CRM_Core_Session::singleton();
+      $user_contact = (int) $session->get('userID');
+      CRM_Core_BAO_Setting::setItem($values['campaign_id'],            'de.systopia.rcont', 'last_campaign_id', NULL, $user_contact);
+      CRM_Core_BAO_Setting::setItem($values['cycle_day'],              'de.systopia.rcont', 'last_cycle_day', NULL, $user_contact);
+      CRM_Core_BAO_Setting::setItem($values['financial_type_id'],      'de.systopia.rcont', 'last_financial_type_id', NULL, $user_contact);
+      CRM_Core_BAO_Setting::setItem($values['frequency'],              'de.systopia.rcont', 'last_frequency', NULL, $user_contact);
+      CRM_Core_BAO_Setting::setItem($values['contribution_status_id'], 'de.systopia.rcont', 'last_contribution_status_id', NULL, $user_contact);
+    }
 
     // compile contribution object with required values
     $rcontribution = array(
@@ -320,11 +322,12 @@ class CRM_Rcont_Form_RecurEdit extends CRM_Core_Form {
       return CRM_Utils_array::value($key, $this->_submitValues);
     } elseif (CRM_Utils_Array::value($key, $rcontribution)) {
       return CRM_Utils_Array::value($key, $rcontribution);
-    } else {
+    } elseif (Civi::settings()->get('rcont_remember_values')) {
       $session = CRM_Core_Session::singleton();
       $user_contact = (int) $session->get('userID');
       return CRM_Core_BAO_Setting::getItem('de.systopia.rcont', "last_$key", NULL, NULL, $user_contact);
     }
+    return NULL;
   }
 
   /**

--- a/CRM/Rcont/Form/RecurEdit.php
+++ b/CRM/Rcont/Form/RecurEdit.php
@@ -346,6 +346,9 @@ class CRM_Rcont_Form_RecurEdit extends CRM_Core_Form {
       $session = CRM_Core_Session::singleton();
       $user_contact = (int) $session->get('userID');
       return CRM_Core_BAO_Setting::getItem('de.systopia.rcont', "last_$key", NULL, NULL, $user_contact);
+    } else {
+      // custom form field defaults can be configured via rcont_default_field_name settings
+      return Civi::settings()->get("rcont_default_{$key}");
     }
     return NULL;
   }

--- a/settings/rcont.setting.php
+++ b/settings/rcont.setting.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+  'rcont_remember_values' => [
+    'name' => 'rcont_remember_values',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => TRUE,
+    'html_type' => 'radio',
+    'add' => '0.7',
+    'title' => ts('Remember previously entered recurring contribution form values?'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('If enabled, Recurring Contributions Tools will remember the previously entered values and use them to prefill the form.'),
+  ]
+];


### PR DESCRIPTION
This adds some improvements to the recurring contribution form. Most of the changes are configurable and the defaults remain unchanged.

- **Add setting for "remember last form value" feature**
This adds a setting called `rcont_remember_values` that makes it possible to change the form behaviour to not remember the previously entered form values to use them to prefill the form for new recurring contributions. The default behaviour remains unchanged.
- **Add (empty) default values for various form fields**
  This changes the recurring contribution form to add an empty default value for some fields, and for fields where that's appropriate, an actual default value.

  The goal is to trigger the required fields validation when users skip over a field rather than selecting the value that just happens to be the first option in the `<select>`.

  This is mostly useful in connection with `rcont_remember_values` set to `0`, as the form would otherwise just prefill the previously entered values.
- **Add configurable default form values**
This adds a way to set configurable default values for any form fields. Default fields can be set by adding a `rcont_default_field_name` setting with the corresponding value.