### PR TITLE
Fix cycle day being off by one

### DIFF
--- a/CRM/Rcont/Form/RecurEdit.php
+++ b/CRM/Rcont/Form/RecurEdit.php
@@ -87,7 +87,10 @@ class CRM_Rcont_Form_RecurEdit extends CRM_Core_Form {
     $cycle_day_list = [
       '' => ts('- none -'),
     ];
-    $cycle_day_list += range(1, 31);
+    $cycle_day_list += range(0, 31);
+    // remove the first item, resulting in a one-based array where array keys
+    // match the label
+    unset($cycle_day_list[0]);
     $cycle_day_list[29] = "29 " . ts('(may cause problems)');
     $cycle_day_list[30] = "30 " . ts('(may cause problems)');
     $cycle_day_list[31] = "31 " . ts('(may cause problems)');


### PR DESCRIPTION
This fixes an issue introduced in #1 where cycle days are set to the selected value minus one due to a difference between the array keys and the displayed drop-down label.

Turns out I should be more careful replacing code that feels weird, there might be a good reason for it. 😁