### PR TITLE
CiviCRM 5.68 compatibility and PHP 8 Compatibility

### DIFF
--- a/rcont.civix.php
+++ b/rcont.civix.php
@@ -95,13 +95,7 @@ function _rcont_civix_civicrm_config(&$config = NULL) {
 
   $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
+  $template->addTemplateDir($extDir);
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);


### PR DESCRIPTION
This fixes an issue with CiviCRm 5.68 and PHP 8.